### PR TITLE
Updated to work with wow API 9.0.1 / TBC 2.5.1

### DIFF
--- a/CEPGP_BulkAward.lua
+++ b/CEPGP_BulkAward.lua
@@ -45,7 +45,7 @@ local function CreateMultilineEditBox(parent)
     },
   }
 
-  local f        = CreateFrame("Frame", "$parent_MultilineEdit", parent)
+  local f        = CreateFrame("Frame", "$parent_MultilineEdit", parent, BackdropTemplateMixin and "BackdropTemplate")
   f:SetSize(500, 300)
   --f:SetPoint("CENTER")
   f:SetFrameStrata("BACKGROUND")

--- a/CEPGP_BulkAward.toc
+++ b/CEPGP_BulkAward.toc
@@ -1,8 +1,8 @@
-## Interface: 11305
+## Interface: 20501
 ## Title: CEPGP_BulkAward
 ## Author: Kvakvs @ github.com/kvakvs/CEPGP_BulkAward
 ## Notes: Provides functionality to bulk modify EP from a name/value pairs list
-## Version: 1.0.1
+## Version: 1.0.3
 ## Dependencies: CEPGP
 ## DefaultState: enabled
 ## SavedVariables: 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ This addon allows batch modification of EP (only! not GP) via a multi-line comma
 
 `Playername,value,message`
 eg:
-`Raider1,50,Bonus EP`
-`Raider2,-10,Mistakenly added EP`
-`Raider3,50,Bonus EP`
+```
+Raider1,50,Bonus EP
+Raider2,-10,Mistakenly added EP
+Raider3,50,Bonus EP
+```
 
 Each line will show as a separate entry in the EPGP Traffic window.
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Description
+
+This addon allows batch modification of EP (only! not GP) via a multi-line comma-separated list of values, in the following format:
+
+`Playername,value,message`
+eg:
+`Raider1,50,Bonus EP`
+`Raider2,-10,Mistakenly added EP`
+`Raider3,50,Bonus EP`
+
+Each line will show as a separate entry in the EPGP Traffic window.
+
+# Usage
+
+To use, open the in-game menu and go to Interface --> Addons --> CEPGP Bulk Award.
+Fill you data into the edit box provided and click Apply Changes.


### PR DESCRIPTION
As per https://github.com/Stanzilla/WoWUIBugs/wiki/9.0.1-Consolidated-UI-Changes, the wow API no longer provides the backdrop API to frames unless they specifically ask for it.

I've simply opted in for the backdrop API, as well as provided some usage documentation for the addon