### PR TITLE
Re-introduced previous fix to handle special chars

### DIFF
--- a/CEPGP_BulkAward.lua
+++ b/CEPGP_BulkAward.lua
@@ -82,7 +82,10 @@ function CEPGPBA_OnApplyChanges(text)
   -- Split text into lines
   for ln in string.gmatch(text, "[^\r\n]+") do
     local player, amount, msg
-    player, amount, msg = string.match(ln, "(%a+),(-?%d+),(.*)")
+    local split = CEPGP_split(ln,",")
+    player = split[1]
+    amount = split[2]
+    msg = split[3]
     do
       CEPGP_addEP(player, tonumber(amount), msg)
     end


### PR DESCRIPTION
Using the existing `string.match` operation to split the input string can result in edge cases which break the import.

The following input data:
```
Test,50,Fake message
Testáxxx,50,Fake message
```

After the `string.match` operation looks like:
```
Test,50,Fake message
xxx,50,Fake message
```

These changes cater for special characters by splitting on a `,` character.